### PR TITLE
Add on/off switch for try logic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -83,6 +83,7 @@ let schema = Joi.object().keys({
   }),
 
   try: Joi.object().keys({
+    enabled: Joi.boolean().required(),
     defaultUrl: Joi.string().required().
       description('Default url (with mustache params) to use to fetch taskgraph'),
 

--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -46,6 +46,7 @@ commitPublisher:
     be sent as events...
 
 try:
+  enabled: true
   # Default url used when figuring out where to fetch task graph has some special
   # mustache parameters used to customize the path.
   #

--- a/src/config/production.yml
+++ b/src/config/production.yml
@@ -17,3 +17,8 @@ treeherderTaskcluster:
 kue:
   purgeCompleted: true
   prefix: production
+
+# Disable try functionality on production configs the staging
+# version for now creates all task graphs...
+try:
+  enabled: false

--- a/src/jobs/treeherder_resultset.js
+++ b/src/jobs/treeherder_resultset.js
@@ -56,7 +56,7 @@ export default class TreeherderResultsetJob extends Base {
     let lastRev = resultset.revisions[resultset.revisions.length - 1];
     let tryProject = this.projects[repo.alias];
 
-    if (tryProject) {
+    if (this.config.try.enabled && tryProject) {
       if (
         tryProject.contains &&
         lastRev.comment.indexOf(tryProject.contains) === -1


### PR DESCRIPTION
This allows staging environment to handle all task graph creation for
now so we don't end up running twice the work for no reason.