### PR TITLE
Increase polling interval of pushlog

### DIFF
--- a/src/pushlog/monitor.js
+++ b/src/pushlog/monitor.js
@@ -155,7 +155,7 @@ export default class Monitor {
     await Promise.all(ops);
   }
 
-  async start(checkInterval=2000) {
+  async start(checkInterval=10000) {
     if (this._intervalHandle) throw new Error('Already running...');
     debug('start : interval %d', this.interval)
 


### PR DESCRIPTION
TaskCluster is currently spamming hg.mozilla.org with >100k pushlog
requests per hour. This would arguably be acceptable if pushlog were
respecting 503 errors and performing a backoff when the service is
offline. But it isn't.

Until TaskCluster becomes a better citizen, reduce the pushlog polling
interval so it doesn't send so much load hg.mozilla.org's way.