### PR TITLE
Enable Taskcluster jobs on Alder for bug 1157242.

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -95,4 +95,6 @@ try:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
     cypress:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+    alder:
+      url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
 


### PR DESCRIPTION
I'm working on getting some Buildbot jobs into the task graph in https://bugzilla.mozilla.org/show_bug.cgi?id=1157242, so I'll need to get taskcluster-graph to start running on Alder to test/verify my work.