### PR TITLE
Production should create task graphs and not rely on staging

### DIFF
--- a/src/config/production.yml
+++ b/src/config/production.yml
@@ -17,8 +17,3 @@ treeherderTaskcluster:
 kue:
   purgeCompleted: true
   prefix: production
-
-# Disable try functionality on production configs the staging
-# version for now creates all task graphs...
-try:
-  enabled: false

--- a/src/config/stage.yml
+++ b/src/config/stage.yml
@@ -16,3 +16,8 @@ treeherderTaskcluster:
 
 kue:
   prefix: stage
+
+# Disable try functionality on staging configs the production
+# version for now creates all task graphs...
+try:
+  enabled: false


### PR DESCRIPTION
This will allow mozilla-taskcluster to use production treeherder rather than staging.