### PR TITLE
Bug 1216306: use roles for trees

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -90,10 +90,6 @@ let schema = Joi.object().keys({
     errorTaskUrl: Joi.string().required().
       description('Location of the "error" task to use if we cannot parse the yaml'),
 
-    defaultScopes:
-      Joi.array().includes(Joi.string()).required().
-        description('List of default scopes to restrict graph to'),
-
     projects: Joi.object().pattern(/.*/, Joi.object({
       scopes: Joi.array(),
       url: Joi.string(),

--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -62,50 +62,45 @@ try:
   # XXX: This url is temporary until a real one hits mozilla-central.
   errorTaskUrl: "https://gist.githubusercontent.com/gregarndt/8fc123be2408180c2f13/raw/d12f500faa334bc72cb1dd033e028773ac2476c8/error.yml"
 
-  # Default scopes to use for projects which have no specific scopes of their own.
-  defaultScopes:
-    - queue:*
-    - docker-worker:*
-    - scheduler:*
-
   projects:
     # Try is the definitive example:
     try: # Note the keys match the "alias" which treeherder defines.
-      # The url overrides the default url mapping and may include same mustache
-      # parameters...
-      # url: ...
-
-      # The commit _must_ contain +tc to be scheduled...
       contains: 'try:'
-
-      # The graph will be restricted to the following scopes this should ideally be
-      # as locked down as possible.
-      # scopes: []
-      #
       scopes:
-        - queue:*
-        - scheduler:*
-        - docker-worker:cache:*
-        - docker-worker:image:*
-        - docker-worker:capability:device:loopbackAudio
-        - docker-worker:capability:device:loopbackVideo
-        - docker-worker:relengapi-proxy:tooltool.download.internal
-        - docker-worker:relengapi-proxy:tooltool.download.public
+        - "assume:moz-tree:try"
     mozilla-b2g34_v2_1s:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:mozilla-b2g34_v2_1s"
     b2g-inbound:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:b2g-inbound"
     mozilla-inbound:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:mozilla-inbound"
     fx-team:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:fx-team"
     mozilla-central:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:mozilla-central"
     cedar:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:cedar"
     cypress:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:cypress"
     alder:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
+      scopes:
+        - "assume:moz-tree:alder"
     pine:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"  
+      scopes:
+        - "assume:moz-tree:pine"

--- a/src/project_scopes.js
+++ b/src/project_scopes.js
@@ -26,7 +26,7 @@ function getProject(config, name, allowMissing = false) {
 
 export function scopes(config, project, allowMissing = false) {
   let project = getProject(config, project, allowMissing);
-  return project.scopes || config.defaultScopes;
+  return project.scopes || [];
 }
 
 export function url(config, project, params = {}) {

--- a/test/project_scopes_test.js
+++ b/test/project_scopes_test.js
@@ -4,7 +4,6 @@ import * as subject from '../src/project_scopes';
 suite('project scopes', function() {
 
   let config = {
-    defaultScopes: ['woot'],
     defaultUrl: '{{{host}}} {{{path}}} {{{revision}}} {{{alias}}}',
     projects: {
       defaults: {},
@@ -20,7 +19,7 @@ suite('project scopes', function() {
   test('#scopes', function() {
     assert.equal(
       subject.scopes(config, 'defaults'),
-      config.defaultScopes
+      []
     );
 
     assert.equal(


### PR DESCRIPTION
This shifts mozilla-taskcluster to use roles named
`moz-tree:{{{alias}}}` for each tree (aka project aka alias) instead of
hard-coding the tree's scopes.