### PR TITLE
Include project in logging statements

### DIFF
--- a/src/bin/create_graph.js
+++ b/src/bin/create_graph.js
@@ -51,7 +51,6 @@ run(async function main(runtime, config, args) {
   });
 
   await job.work({
-    log: console.log.bind(console),
     data: {
       pushref: { id: pushid },
       repo: repo,

--- a/src/jobs/retrigger.js
+++ b/src/jobs/retrigger.js
@@ -84,7 +84,7 @@ export default class RetriggerJob extends Base {
     let { taskId, runId, requester, project } = job.data;
     let task = await queue.task(taskId);
 
-    job.log(`Posting retrigger for job ${taskId} in project ${project}`);
+    console.log(`Handling retrigger for job ${taskId} in project '${project}'`);
     // Ensure when retrigger is sent that we use the right scopes for the job.
     let scopes = projectConfig.scopes(this.config.try, project, true);
     let scheduler = new taskcluster.Scheduler({
@@ -124,8 +124,15 @@ export default class RetriggerJob extends Base {
       tasks: transformedTasks
     };
 
-    job.log(`Task graph id ${newGraphId}`);
-    await scheduler.createTaskGraph(newGraphId, graph);
+    console.log(
+        `Posting retrigger job for '${project}' with id ${newGraphId}`
+    );
+    try {
+      await scheduler.createTaskGraph(newGraphId, graph);
+    } catch (e) {
+      console.log(`Error posting retrigger job for '${project}', ${JSON.stringify(e, null, 2)}`);
+      throw e;
+    }
 
     let message = {
       requester,

--- a/src/jobs/taskcluster_graph.js
+++ b/src/jobs/taskcluster_graph.js
@@ -43,7 +43,7 @@ Fetch a task graph from a url (retires included...)
 */
 async function fetchGraph(job, url) {
   assert(url, 'url is required');
-  job.log(`fetching graph ${url}`);
+  console.log(`fetching graph ${url}`);
   let opts = { interval: GRAPH_INTERVAL, retires: GRAPH_RETIRES };
   try {
     return await retry(opts, async () => {
@@ -93,7 +93,7 @@ export default class TaskclusterGraphJob extends Base {
     };
 
     let graphUrl = projectConfig.url(this.config.try, repo.alias, urlVariables);
-    job.log('Fetching url (%s) for %s push id %d ', graphUrl, repo.alias, push.id);
+    console.log('Fetching url (%s) for '%s' push id %d ', graphUrl, repo.alias, push.id);
     let graphText = await fetchGraph(job, graphUrl);
 
     let variables = {
@@ -113,7 +113,7 @@ export default class TaskclusterGraphJob extends Base {
     try {
       graph = instantiate(graphText, variables);
     } catch (e) {
-      job.log("Error creating graph due to yaml syntax errors...");
+      console.log("Error creating graph due to yaml syntax errors...");
       // Even though we won't end up doing anything overly useful we still need
       // to convey some status to the end user ... The instantiate error should
       // be safe to pass as it is simply some yaml error.
@@ -136,11 +136,14 @@ export default class TaskclusterGraphJob extends Base {
     // Assign maximum level of scopes to the graph....
     graph.scopes = scopes;
 
-    job.log('Posting job with id %s and scopes', id, graph.scopes.join(', '));
+    console.log(
+        `Posting job for project '${repo.alias}' with id ${id} ` +
+        `and scopes ${graph.scopes.join(', ')}`
+    );
     try {
       await scheduler.createTaskGraph(id, graph);
     } catch (e) {
-      console.log(JSON.stringify(e, null, 2))
+      console.log(`Error posting job for '${repo.alias}', ${JSON.stringify(e, null, 2)}`);
       throw e;
     }
   }

--- a/src/jobs/treeherder_resultset.js
+++ b/src/jobs/treeherder_resultset.js
@@ -40,7 +40,7 @@ export default class TreeherderResultsetJob extends Base {
     let push = await this.runtime.pushlog.getOne(repo.url, pushref.id);
 
     if (!cred) {
-      job.log('No credentials for %s skipping', repo.alias);
+      console.log(`No credentials for project ${repo.alias}, skipping`);
       return;
     }
 
@@ -60,7 +60,7 @@ export default class TreeherderResultsetJob extends Base {
     // previous commit like code comments or modify something that is not part
     // of CI.
     if (lastRev.comment.indexOf("DONTBUILD") !== -1) {
-      job.log("Commit contains DONTBUILD skipping...");
+      console.log(`Commit for project '${repo.alias}' contains DONTBUILD, skipping`);
       return;
     }
 
@@ -69,10 +69,13 @@ export default class TreeherderResultsetJob extends Base {
         tryProject.contains &&
         lastRev.comment.indexOf(tryProject.contains) === -1
       ) {
-        job.log(`skipping graph project does not contain ${tryProject.contains}`)
+        console.log(
+            `Skipping submitting graph for project '${repo.alias}'. ` +
+            `Commit does not contain ${tryProject.contains}`
+        );
         return;
       }
-      job.log('scheduling taskcluster jobs');
+      console.log(`Scheduling taskcluster jobs for project '${repo.alias}'`);
       await this.scheduleTaskGraphJob(resultset, repo, pushref);
     }
   }


### PR DESCRIPTION
Just a start with getting some useful things in the logs.  It appears that "job.log" wasn't actually getting captured in the logs.  Just made it a straight forward console.log() call like everywhere else.