### PR TITLE
Create project instance if one does not exist

### DIFF
--- a/src/jobs/treeherder_resultset.js
+++ b/src/jobs/treeherder_resultset.js
@@ -56,7 +56,7 @@ export default class TreeherderResultsetJob extends Base {
     if(!this.config.try.enabled) {
       console.log(
         'Creation of task graphs is disabled.  Task graph creation can ' +
-        'be enabled by setting try.enabled to 'true' in the configuration'
+        'be enabled by setting try.enabled to \'true\' in the configuration'
       );
       return;
     }

--- a/src/jobs/treeherder_resultset.js
+++ b/src/jobs/treeherder_resultset.js
@@ -82,7 +82,7 @@ export default class TreeherderResultsetJob extends Base {
       return;
     }
 
-    if (tryProject.contains && lastRev.comment.includes(tryProject.contains)) {
+    if (tryProject.contains && !lastRev.comment.includes(tryProject.contains)) {
       console.log(
           `Skipping submitting graph for project '${repo.alias}'. ` +
           `Commit does not contain ${tryProject.contains}`

--- a/src/jobs/treeherder_resultset.js
+++ b/src/jobs/treeherder_resultset.js
@@ -53,8 +53,26 @@ export default class TreeherderResultsetJob extends Base {
       throw e;
     }
 
-    let lastRev = resultset.revisions[resultset.revisions.length - 1];
+    if(!this.config.try.enabled) {
+      console.log(
+        'Creation of task graphs is disabled.  Task graph creation can ' +
+        'be enabled by setting try.enabled to 'true' in the configuration'
+      );
+      return;
+    }
+
     let tryProject = this.projects[repo.alias];
+    // We only want to schedule task graphs for those projects that are explicitly
+    // enabled.
+    if (!tryProject) {
+      console.log(
+        `Task graph will not be created for project '${repo.alias}'. ` +
+        `Project must be added to configuration for task graphs to be submitted.`
+      );
+      return;
+    }
+
+    let lastRev = resultset.revisions[resultset.revisions.length - 1];
 
     // Common idom is to include "DONTBUILD" in changes to ammend something in a
     // previous commit like code comments or modify something that is not part
@@ -64,19 +82,15 @@ export default class TreeherderResultsetJob extends Base {
       return;
     }
 
-    if (this.config.try.enabled && tryProject) {
-      if (
-        tryProject.contains &&
-        lastRev.comment.indexOf(tryProject.contains) === -1
-      ) {
-        console.log(
-            `Skipping submitting graph for project '${repo.alias}'. ` +
-            `Commit does not contain ${tryProject.contains}`
-        );
-        return;
-      }
-      console.log(`Scheduling taskcluster jobs for project '${repo.alias}'`);
-      await this.scheduleTaskGraphJob(resultset, repo, pushref);
+    if (tryProject.contains && lastRev.comment.includes(tryProject.contains)) {
+      console.log(
+          `Skipping submitting graph for project '${repo.alias}'. ` +
+          `Commit does not contain ${tryProject.contains}`
+      );
+      return;
     }
+
+    console.log(`Scheduling taskcluster jobs for project '${repo.alias}'`);
+    await this.scheduleTaskGraphJob(resultset, repo, pushref);
   }
 }

--- a/src/treeherder/job_handler.js
+++ b/src/treeherder/job_handler.js
@@ -200,22 +200,15 @@ function jobFromTask(taskId, task, run) {
 
 class Handler {
   constructor(config, listener) {
+    this.config = config;
     this.queue = new Queue();
     this.scheduler = new Scheduler();
 
     this.prefix = config.treeherderTaskcluster.routePrefix;
     this.listener = listener;
 
-    this.projects = Object.keys(config.try.projects).reduce((result, key) => {
-      result[key] = new Project(key, {
-        clientId: config.treeherder.credentials.clientId,
-        secret: config.treeherder.credentials.secret,
-        baseUrl: config.treeherder.apiUrl,
-        // Issue up to 2 retries for 429 throttle issues.
-        throttleRetries: 2
-      });
-      return result;
-    }, {});
+    // Treeherder project instances used for posting job details to treeherder
+    this.project = {}
 
     listener.on('message', (message) => {
       return this.handleTaskEvent(message);
@@ -461,6 +454,28 @@ class Handler {
   }
 
   /**
+   * Create (or return an existing) treeherder project instance for a given
+   * project.
+   *
+   * @param {String} projectName - Name of the treeherder project
+   *
+   * @return {Object} Treeherder project instance
+   */
+  getProject(projectName) {
+    if (!this.projects[projectName]) {
+      this.projects[projectName] = new Project(projectName, {
+          clientId: this.config.treeherder.credentials.clientId,
+          secret: this.config.treeherder.credentials.secret,
+          baseUrl: this.config.treeherder.apiUrl,
+          // Issue up to 2 retries for 429 throttle issues.
+          throttleRetries: 2
+      });
+    }
+
+    return this.projectName[projectName];
+  }
+
+  /**
   Handle an incoming task event and convert it into a pending job push for
   treeherder...
   */
@@ -478,17 +493,12 @@ class Handler {
     // The project and revision hash is encoded as part of the route...
     let [ , project, revisionHash ] = route.split('.');
 
-    if (!this.projects[project]) {
-      console.error('Unknown project', project);
-      return;
-    }
-
     if (!EVENT_MAP[exchange]) {
       console.error('Unknown state', exchange);
       return;
     }
 
-    let treeherderProject = this.projects[project];
+    let treeherderProject = this.getProject(project);
     let task = await this.queue.task(payload.status.taskId);
 
     switch (EVENT_MAP[exchange]) {

--- a/src/treeherder/job_handler.js
+++ b/src/treeherder/job_handler.js
@@ -208,7 +208,7 @@ class Handler {
     this.listener = listener;
 
     // Treeherder project instances used for posting job details to treeherder
-    this.project = {}
+    this.projects = {}
 
     listener.on('message', (message) => {
       return this.handleTaskEvent(message);
@@ -472,7 +472,7 @@ class Handler {
       });
     }
 
-    return this.projectName[projectName];
+    return this.projects[projectName];
   }
 
   /**


### PR DESCRIPTION
Prior to switching to use hawk authentication, there were per project
credentials for treeherder.  This credentials list contained many repos
that by default were getting things pushed to treeherder.  Once
switching over to hawk and no longer having this credentails list,
projects that were once submitting to treeherder are no longer working.
This should allow this to continue on since posting to treeherder does
not require any special privileges from a taskcluster perspective.