### PR TITLE
Bug 1220298: include scheduler:create-task-graph in authorizedScopes

### DIFF
--- a/src/jobs/retrigger.js
+++ b/src/jobs/retrigger.js
@@ -89,7 +89,9 @@ export default class RetriggerJob extends Base {
     let scopes = projectConfig.scopes(this.config.try, project, false);
     let scheduler = new taskcluster.Scheduler({
       credentials: this.config.taskcluster.credentials,
-      authorizedScopes: scopes
+      // include scheduler:create-task-graph so we can call create-task-graph,
+      // but not include it in graph.scopes
+      authorizedScopes: scopes.concat(['scheduler:create-task-graph'])
     });
     let graphDuplicator = new GraphDuplicator(scheduler);
 

--- a/src/jobs/taskcluster_graph.js
+++ b/src/jobs/taskcluster_graph.js
@@ -130,7 +130,9 @@ export default class TaskclusterGraphJob extends Base {
 
     let scheduler = new taskcluster.Scheduler({
       credentials: this.config.taskcluster.credentials,
-      authorizedScopes: scopes
+      // include scheduler:create-task-graph so we can call create-task-graph,
+      // but not include it in graph.scopes
+      authorizedScopes: scopes.concat(['scheduler:create-task-graph'])
     });
 
     // Assign maximum level of scopes to the graph....


### PR DESCRIPTION
Untested, but should be safe enough to land and see what happens when I delete the `repo:*` role.