### PR TITLE
Bug 1242675 - Post to treeherder when retrigger failed

### DIFF
--- a/src/treeherder/job_handler.js
+++ b/src/treeherder/job_handler.js
@@ -122,7 +122,7 @@ function createLogReferences(queue, taskId, run) {
   }];
 }
 
-function jobFromTask(taskId, task, run) {
+export function jobFromTask(taskId, task, run) {
   // Create the default set of options...
   let treeherder = (task.extra && task.extra.treeherder) || {};
   treeherder = merge(


### PR DESCRIPTION
Retriggers are an async operation and if creating the new task graph fails, nothing indicates this within TH for the user to see.

This change will allow an error job be posted to TH that will appear as an exception with an error indicating that the retrigger could not be completed.

Job where this can be seen: 
https://treeherder.allizom.org/#/jobs?repo=mozilla-central&selectedJob=2953881