### PR TITLE
Update option collection types to match treeherder

### DIFF
--- a/src/treeherder/job_handler.js
+++ b/src/treeherder/job_handler.js
@@ -53,7 +53,10 @@ const SCHEMA = Joi.object().keys({
     opt: Joi.boolean(),
     debug: Joi.boolean(),
     pgo: Joi.boolean(),
-    cc: Joi.boolean()
+    cc: Joi.boolean(),
+    asan: Joi.boolean(),
+    tsan: Joi.boolean(),
+    addon: Joi.boolean(),
   }),
 
   revision_hash: Joi.string().allow('').


### PR DESCRIPTION
This is the same list that's found in the option ordering in Treeherder's UI.  This wouldn't have stopped an option of 'asan' from being submitted because unknown(true), but at least now that they're list they'll be validated.