### PR TITLE
Bug 1274391: try `.taskcluster.yml` first

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -49,14 +49,18 @@ commitPublisher:
 # projects, not just try.
 try:
   enabled: true
-  # Default url used when figuring out where to fetch task graph has some special
-  # mustache parameters used to customize the path.
+
+  # This is the preferred location for the decision task file for every repository.
+  # Mustache parameters used to customize the path:
   #
   #   - alias: current key name
   #   - revision: revision of the change
   #   - path: sub path to repository
   #   - host: host of repository
   #
+  tcYamlUrl: "{{{host}}}{{{path}}}/raw-file/{{revision}}/.taskcluster.yml"
+
+  # Default url used when figuring out where to fetch task graph has some special
   defaultUrl: "{{{host}}}{{{path}}}/raw-file/{{revision}}/testing/taskcluster/tasks/decision/branch.yml"
 
   # If for some reason the task yaml is invalid we still would like to create a

--- a/src/project_scopes.js
+++ b/src/project_scopes.js
@@ -34,6 +34,12 @@ export function level(config, project) {
   return project.level || 1;
 }
 
+export function tcYamlUrl(config, params = {}) {
+  Joi.assert(params, URL_SCHEMA);
+  let url = config.tcYamlUrl;
+  return mustache.render(url, params);
+}
+
 export function url(config, project, params = {}) {
   let project = getProject(config, project);
   Joi.assert(params, URL_SCHEMA);


### PR DESCRIPTION
With this change, if a repo has a `.taskcluster.yml`, it will be used to
run the decision task instead of `testing/taskcluster/tasks/decision/<whatever>.yml`.

This should allow a gradual transition as `.taskcluster.yml` is merged around.