### PR TITLE
Bug 1274176: support duplicating subgraphs of big graphs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1967,9 +1967,9 @@
       "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz"
     },
     "taskcluster-client": {
-      "version": "0.21.3",
-      "from": "taskcluster-client@0.21.3",
-      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.21.3.tgz",
+      "version": "1.0.1",
+      "from": "taskcluster-client@1.0.1",
+      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-1.0.1.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "slugid": "^1.1.0",
     "superagent": "git://github.com/visionmedia/superagent#e6c302c2e83cbf76182ea10b6a1ef6fd0d4e0b2b",
     "superagent-promise": "^0.2.0",
-    "taskcluster-client": "0.21.3",
+    "taskcluster-client": "^1.0.1",
     "traverse": "^0.6.6",
     "urljoin": "^0.1.5",
     "uuid": "^2.0.1"

--- a/src/taskcluster/duplicate_task.js
+++ b/src/taskcluster/duplicate_task.js
@@ -34,13 +34,6 @@ export function duplicate(task, now) {
     newTask[field] = updateDateWithDelta(task[field], delta);
   }
 
-  // Task group id should never be duplicated... The scheduler can assign a new
-  // one once the graph is created...
-  delete newTask.taskGroupId;
-  // New task should not have any dependencies...
-  delete newTask.dependencies;
-  delete newTask.requires;
-
   // docker-worker specific dates...
   if (task.payload && typeof task.payload.artifacts === 'object') {
     Object.keys(task.payload.artifacts).forEach((name) => {

--- a/src/taskcluster/duplicator.js
+++ b/src/taskcluster/duplicator.js
@@ -1,0 +1,155 @@
+import _ from 'lodash';
+import taskcluster from 'taskcluster-client';
+import slugid from 'slugid';
+import { duplicate as duplicateTask } from './duplicate_task';
+import Project from 'mozilla-treeherder/project';
+
+// We use public only operations on the queue here...
+const queue = new taskcluster.Queue();
+
+/**
+ * Duplicate task-graph nodes (old scheduler), following dependencies in reverse
+ * to duplicate all tasks depending on the given node as well.
+ */
+export class GraphDuplicator {
+  constructor(scheduler) {
+    this.scheduler = scheduler;
+  }
+
+  /**
+   * Duplicate the task indicated by taskId, including dependencies if
+   * `dependencies` is true.
+   *
+   * NOTE: this does not maintain dependencies on tasks outside of the
+   * duplicated subgraph.
+   *
+   * *output* nodes: pass an empty object as the first parameter; on return
+   * this will contain the duplicated task subgraph, keyed by old taskId.  Each
+   * value has {taskId: <new taskId>, requires: [<dependencies>], task: <task
+   * definition>}.  Task definitions have their task groups stripped and datestamps
+   * updated.
+   *
+   * returns: values of the nodes parameter, in arbitrary order
+   */
+  async duplicateGraphNode(nodes, graphId, taskId, dependencies = false, parent = null) {
+    // If the node has already been duplicated skip...
+    if (nodes[taskId]) {
+      // Add the parent node if available...
+      if (parent) nodes[taskId].requires.push(parent);
+      return;
+    };
+
+    let newTaskId = slugid.nice();
+    let node = nodes[taskId] = {
+      taskId: newTaskId,
+      requires: []
+    }
+
+    // Fetch all details related to the task id...
+    let [task, graphNode] = await Promise.all([
+      queue.task(taskId),
+      this.scheduler.inspectTask(graphId, taskId)
+    ]);
+
+    node.reruns = graphNode.reruns;
+    node.task = duplicateTask(task);
+
+    // Task group id should never be duplicated... The scheduler can assign a new
+    // one once the graph is created...
+    delete newTask.taskGroupId;
+
+    // New task should not have any dependencies...
+    delete node.task.dependencies;
+    delete node.task.requires;
+
+    // Add the parent node if available...
+    if (parent) node.requires.push(parent);
+    // Add dependencies if explicitly desired.
+    if (dependencies && graphNode.dependents) {
+      // Read though the dependencies and add them to the graph...
+      await Promise.all(graphNode.dependents.map(async (childTaskId) => {
+        await this.duplicateGraphNode(nodes, graphId, childTaskId, true, newTaskId);
+      }));
+    }
+
+    return Object.keys(nodes).reduce((result, value) => {
+      result.push(nodes[value]);
+      return result;
+    }, []);
+  }
+}
+
+/**
+ * Duplicate a task in a task group (big-graph scheduler), following reverse dependencies
+ * to duplicate all tasks that depend on this one as well.
+ */
+export class GroupDuplicator {
+  constructor(queue) {
+    this.queue = queue;
+  }
+
+  /**
+   * Duplicate the task indicated by taskId, including dependencies if
+   * `dependencies` is true.
+   *
+   * *output* nodes: pass an empty object as the first parameter; on return
+   * this will contain the duplicated task subgraph, keyed by old taskId.  Each
+   * value has {taskId: <new taskId>, task: <task definition>}.  Task dependencies
+   * are included within the task definitions.  Task definitions have their datestamps
+   * updated.
+   *
+   * returns: values of the nodes parameter, in arbitrary order
+   */
+  async duplicateGroupNode(nodes, taskId, dependencies = false, oldParent = null, parent = null) {
+    // If the node has already been duplicated skip...
+    if (nodes[taskId]) {
+      // replace the old parent 
+      if (parent) {
+        this.replaceDependency(nodes[taskId].task, oldParent, parent);
+      }
+      return;
+    };
+
+    let newTaskId = slugid.nice();
+    let node = nodes[taskId] = {
+      taskId: newTaskId,
+      requires: []
+    }
+
+    // Fetch all details related to the task id...
+    let task = await this.queue.task(taskId);
+    node.task = duplicateTask(task);
+    if (parent) {
+      this.replaceDependency(node.task, oldParent, parent);
+    }
+
+    // Add the parent node if available...
+    if (parent) node.requires.push(parent);
+    // Add dependencies if explicitly desired.
+    if (dependencies) {
+      let continuationToken;
+      do {
+        let res = await this.queue.listDependentTasks(taskId, {continuationToken});
+        continuationToken = res.continuationToken;
+        // Read though the dependencies and add them to the graph, sequentially to
+        // avoid pounding the queue API with many concurrent requests
+        for (let {status} of res.tasks) {
+          await this.duplicateGroupNode(nodes, status.taskId, true, taskId, newTaskId);
+        }
+      } while (continuationToken);
+
+    }
+
+    return Object.keys(nodes).reduce((result, value) => {
+      result.push(nodes[value]);
+      return result;
+    }, []);
+  }
+
+  replaceDependency(task, oldTaskId, newTaskId) {
+    _.remove(task.dependencies, tid => tid === oldTaskId);
+    task.dependencies.push(newTaskId);
+  }
+}
+
+

--- a/test/jobs/retrigger_test.js
+++ b/test/jobs/retrigger_test.js
@@ -1,0 +1,110 @@
+import assert from 'assert';
+import _ from 'lodash';
+import slugid from 'slugid';
+import RetriggerJob from '../../build/jobs/retrigger';
+
+suite('jobs/retrigger', function() {
+  suite('RetriggerJob', function() {
+    var createdTasks, tasks, job;
+
+    let addTask = (taskId, body) => {
+      tasks.push(_.defaults(body, {taskId, dependencies: []}));
+    };
+
+    let fakeQueue = {};
+    fakeQueue.task = async (taskId) => {
+      let task = _.find(tasks, {taskId});
+      if (task) {
+        return _.omit(task, ['taskId']);
+      } else {
+        throw new Error("no such task sorry");
+      }
+    };
+
+    // listDependentTasks only returns up to two dependent
+    // tasks, to test the continuationToken handling
+    fakeQueue.listDependentTasks = async (taskId, options) => {
+      let offset = 0;
+      if (options && options.continuationToken) {
+        offset = JSON.parse(options.continuationToken);
+      }
+
+      let depTasks = _.filter(tasks,
+          t => t.dependencies.indexOf(taskId) !== -1);
+
+      // convert to a semblance of the return value from listDependentTasks
+      depTasks = _.map(depTasks, (t) => { return {status: {taskId: t.taskId}, task: {}}; });
+
+      // slice down given the offset
+      depTasks = _.slice(depTasks, offset, offset + 2);
+
+      return {
+        taskId,
+        tasks: depTasks,
+        continuationToken: depTasks.length ? JSON.stringify(offset + 2) : undefined,
+      }
+    };
+
+    fakeQueue.createTask = async (taskId, taskDef) => {
+      createdTasks.push({taskId, taskDef});
+    };
+
+    setup(function() {
+      job = new RetriggerJob({config: {}, runtime: {}, publisher: {}});
+      tasks = [];
+      createdTasks = [];
+    });
+
+    suite('duplicateTaskInTaskGroup', function() {
+      test("duplicating a subgraph generates the right calls to queue.createTask", async function() {
+        addTask('build', {payload: 'build', dependencies: ['other1'], taskGroupId: 'tgid'});
+        addTask('test1', {payload: 'test1', dependencies: ['build', 'other2']});
+        addTask('test2', {payload: 'test2', dependencies: ['build', 'test1']});
+        addTask('sign', {payload: 'sign', dependencies: ['test1', 'test2', 'other3']});
+        let res = await job.duplicateTaskInTaskGroup('try', fakeQueue, 'build');
+        assert.equal(res, 'tgid');
+        let newTaskIds = _.reduce(createdTasks, (result, create) => {
+          result[create.taskDef.payload] = create.taskId;
+          return result;
+        }, {});
+        _.forEach(createdTasks, create => create.taskDef.dependencies.sort());
+        assert.deepEqual(createdTasks, [
+          {
+            "taskDef": {
+              "dependencies": ["other1"].sort(),
+              "payload": "build",
+              "taskGroupId": "tgid"
+            },
+            "taskId": newTaskIds['build']
+          },
+          {
+            "taskDef": {
+              "dependencies": ["other2", newTaskIds['build']].sort(),
+              "payload": "test1"
+            },
+            "taskId": newTaskIds['test1']
+          },
+          {
+            "taskDef": {
+              "dependencies": [newTaskIds['build'], newTaskIds['test1']].sort(),
+              "payload": "test2"
+            },
+            "taskId": newTaskIds['test2']
+          },
+          {
+            "taskDef": {
+              "dependencies": [
+                "other3",
+                newTaskIds['test1'],
+                newTaskIds['test2']
+              ].sort(),
+              "payload": "sign"
+            },
+            "taskId": newTaskIds['sign']
+          }
+        ]);
+      });
+    });
+  });
+});
+

--- a/test/taskcluster/duplicator_test.js
+++ b/test/taskcluster/duplicator_test.js
@@ -1,0 +1,135 @@
+import assert from 'assert';
+import _ from 'lodash';
+import slugid from 'slugid';
+import {GroupDuplicator} from '../../build/taskcluster/duplicator';
+
+suite('taskcluster/duplicator', function() {
+  suite('GroupDuplicator', function() {
+    var tasks;
+
+    let addTask = (taskId, body) => {
+      tasks.push(_.defaults(body, {taskId, dependencies: []}));
+    };
+
+    let fakeQueue = {};
+    fakeQueue.task = async (taskId) => {
+      let task = _.find(tasks, {taskId});
+      if (task) {
+        return _.omit(task, ['taskId']);
+      } else {
+        throw new Error("no such task sorry");
+      }
+    };
+
+    // listDependentTasks only returns up to two dependent
+    // tasks, to test the continuationToken handling
+    fakeQueue.listDependentTasks = async (taskId, options) => {
+      let offset = 0;
+      if (options && options.continuationToken) {
+        offset = JSON.parse(options.continuationToken);
+      }
+
+      let depTasks = _.filter(tasks,
+          t => t.dependencies.indexOf(taskId) !== -1);
+
+      // convert to a semblance of the return value from listDependentTasks
+      depTasks = _.map(depTasks, (t) => { return {status: {taskId: t.taskId}, task: {}}; });
+
+      // slice down given the offset
+      depTasks = _.slice(depTasks, offset, offset + 2);
+
+      return {
+        taskId,
+        tasks: depTasks,
+        continuationToken: depTasks.length ? JSON.stringify(offset + 2) : undefined,
+      }
+    };
+
+    let checkReturnValuesMatch = (taskNodes, res, expectedOldTaskIds) => {
+      assert.deepEqual(res.sort(), _.values(taskNodes).sort());
+      assert.deepEqual(_.keys(taskNodes).sort(), expectedOldTaskIds.sort())
+      let newTaskId = {};
+      _.forEach(taskNodes, (node, oldTaskId) => { newTaskId[oldTaskId] = node.taskId; });
+      return newTaskId;
+    };
+
+    let duplicator = new GroupDuplicator(fakeQueue);
+
+    setup(function() {
+      tasks = [];
+    });
+
+    test("duplicating a single node creates a matching task, with taskGroupId and requires intact", async function() {
+      addTask('single', {payload: 'test', requires: 'all-complete', taskGroupId: 'just-the-best-tasks'});
+      let taskNodes = {};
+      let res = await duplicator.duplicateGroupNode(taskNodes, 'single', true);
+      checkReturnValuesMatch(taskNodes, res, ['single']);
+      assert.deepEqual(taskNodes['single'].task.payload, 'test');
+      assert.deepEqual(taskNodes['single'].task.requires, 'all-complete');
+      assert.deepEqual(taskNodes['single'].task.taskGroupId, 'just-the-best-tasks');
+    });
+
+    test("duplicating a node with dependencies=false creates a single matching task", async function() {
+      addTask('test', {payload: 'test', dependencies: ['build']});
+      addTask('build', {payload: 'build'});
+      let taskNodes = {};
+      let res = await duplicator.duplicateGroupNode(taskNodes, 'build', false);
+      checkReturnValuesMatch(taskNodes, res, ['build']);
+      assert.deepEqual(taskNodes['build'].task.payload, 'build');
+    });
+
+    test("duplicating a node with a lot of deps captures those deps", async function() {
+      addTask('build', {payload: 'build'});
+      addTask('test1', {payload: 'test1', dependencies: ['build']});
+      addTask('test2', {payload: 'test2', dependencies: ['build']});
+      addTask('test3', {payload: 'test3', dependencies: ['build']});
+      addTask('test4', {payload: 'test4', dependencies: ['build']});
+      let taskNodes = {};
+      let res = await duplicator.duplicateGroupNode(taskNodes, 'build', true);
+      let newTaskId = checkReturnValuesMatch(taskNodes, res,
+        ['build', 'test1', 'test2', 'test3', 'test4']);
+      assert.deepEqual(taskNodes['build'].task.payload, 'build');
+      assert.deepEqual(taskNodes['build'].task.dependencies, []);
+      assert.deepEqual(taskNodes['test1'].task.payload, 'test1');
+      assert.deepEqual(taskNodes['test1'].task.dependencies, [newTaskId['build']]);
+      assert.deepEqual(taskNodes['test2'].task.payload, 'test2');
+      assert.deepEqual(taskNodes['test2'].task.dependencies, [newTaskId['build']]);
+      assert.deepEqual(taskNodes['test3'].task.payload, 'test3');
+      assert.deepEqual(taskNodes['test3'].task.dependencies, [newTaskId['build']]);
+      assert.deepEqual(taskNodes['test4'].task.payload, 'test4');
+      assert.deepEqual(taskNodes['test4'].task.dependencies, [newTaskId['build']]);
+    });
+
+    test("duplicating a subgraph maintains external dependencies", async function() {
+      addTask('build', {payload: 'build', dependencies: ['other1']});
+      addTask('test1', {payload: 'test1', dependencies: ['build', 'other2']});
+      let taskNodes = {};
+      let res = await duplicator.duplicateGroupNode(taskNodes, 'build', true);
+      let newTaskId = checkReturnValuesMatch(taskNodes, res, ['build', 'test1']);
+      assert.deepEqual(taskNodes['build'].task.payload, 'build');
+      assert.deepEqual(taskNodes['build'].task.dependencies, ['other1']);
+      assert.deepEqual(taskNodes['test1'].task.payload, 'test1');
+      assert.deepEqual(taskNodes['test1'].task.dependencies.sort(), [newTaskId['build'], 'other2'].sort());
+    });
+
+    test("duplicating a diamond-shaped subgraph gets dependencies right", async function() {
+      addTask('build', {payload: 'build', dependencies: ['other1']});
+      addTask('test1', {payload: 'test1', dependencies: ['build', 'other2']});
+      addTask('test2', {payload: 'test2', dependencies: ['build']});
+      addTask('sign', {payload: 'sign', dependencies: ['test1', 'test2', 'other3']});
+      let taskNodes = {};
+      let res = await duplicator.duplicateGroupNode(taskNodes, 'build', true);
+      let newTaskId = checkReturnValuesMatch(taskNodes, res,
+        ['build', 'test1', 'test2', 'sign']);
+      assert.deepEqual(taskNodes['build'].task.payload, 'build');
+      assert.deepEqual(taskNodes['build'].task.dependencies, ['other1']);
+      assert.deepEqual(taskNodes['test1'].task.payload, 'test1');
+      assert.deepEqual(taskNodes['test1'].task.dependencies.sort(), [newTaskId['build'], 'other2'].sort());
+      assert.deepEqual(taskNodes['test2'].task.payload, 'test2');
+      assert.deepEqual(taskNodes['test2'].task.dependencies, [newTaskId['build']]);
+      assert.deepEqual(taskNodes['sign'].task.payload, 'sign');
+      assert.deepEqual(taskNodes['sign'].task.dependencies.sort(),
+        [newTaskId['test1'], newTaskId['test2'], 'other3'].sort());
+    });
+  });
+});


### PR DESCRIPTION
* upgrade to tc-client@1.0.1 to get the new queue methods
* factor subgraph duplication out and implement it for big-graph scheduler
* use subgraph duplication for retriggering tasks in big-graph groups
* tests!

When duplicating in a group, this keeps the new tasks in the same group as the old, and adjusts intra-subgraph dependencies appropriately while maintaining dependencies pointing out of the subgraph.

The new tests do, in fact, pass, and helped track down a number of subtle bugs (some of which also exist in the old task-graph duplicator).  I haven't run this in any kind of staging environment, though, so if you have suggestions for ways I might test that, I'm all ears.