### PR TITLE
Bug 1272612 - Use REDIS_URL environment variable for connection string

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -102,9 +102,8 @@ let schema = Joi.object().keys({
     }))
   }),
 
-  redis: Joi.object().keys({
-    host: Joi.string().required()
-  }).unknown(true),
+  redis: Joi.string().description('Redis connection string').
+           default(Joi.ref('$env.REDIS_URL')),
 
   kue: Joi.object().keys({
     purgeCompleted: Joi.boolean(),


### PR DESCRIPTION
This should be enough (I hope) to remove the redis settings from mongo and rely on the auto-updating environment variable for the connection string.

I would ideally like to land this one staging first once you are done with the retrigger work so I don't conflict with that.
