### PR TITLE
Only attempt to retrigger one time

### DIFF
--- a/src/treeherder/action_handler.js
+++ b/src/treeherder/action_handler.js
@@ -6,7 +6,7 @@ import denodeify from 'denodeify';
 import parseRoute from '../util/route_parser';
 
 const JOB_RETRY_DELAY = 1000 * 10;
-const JOB_ATTEMPTS = 20;
+const JOB_ATTEMPTS = 1;
 
 const SCHEDULER_TYPE = 'task-graph-scheduler';
 


### PR DESCRIPTION
This is to limit the out of control effect when retriggering for some reasons fails at some point in the process.  Before when things were scheduled through the scheduler it was better, but now that each task has it's own createTask event on the queue, somewhere in there things could fail, causing some tasks to be created and another retrigger attempted.