### PR TITLE
Bug 1380704 - Add project for thunderbird experimentation and migration.

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -248,3 +248,13 @@ try:
       level: 'nss-try'
       scopes:
         - "assume:repo:hg.mozilla.org/projects/nss-try:*"
+
+    # This has a repository entry in the DB that was created manually. When this is removed,
+    # the database entry should be removed as well.
+    users/mozilla_hocat.ca/comm-taskcluster:
+      level: 1
+      scopes:
+        - "assume:moz-tree:level:1"
+        - "queue:scheduler-id:gecko-level-1"
+        - "assume:project:thunderbird:*"
+        - "assume:repo:hg.mozilla.org/users/mozilla_hocat.ca/comm-taskcluster"


### PR DESCRIPTION
I'm not sure of the scopes, or if there should be a single role that implies the rest (or where to create it).

This will also need a entry created in the config db for the equivalent of https://github.com/taskcluster/mozilla-taskcluster/blob/master/src/bin/import_repositories.js