### PR TITLE
Turn down the polling interval

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -29,7 +29,7 @@ kue:
     port: 60024
 
 repositoryMonitor:
-  interval: 60000
+  interval: 10000
   maxPushFetches: 200
 
 commitPublisher:


### PR DESCRIPTION
@indygreg suggested this as it will shave an average of 25s off the end-to-end time without creating undue load on hg.m.o