### PR TITLE
Bug 1437563 - read from projects.yml

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -112,7 +112,7 @@ try:
   #  - scopes: scopes for the task graph
   #  - level: SCM level (defaults to 1) passed to the decision task
   projects:
-    # Note that most of this data is loaded from the productionBranchesUrl.
+    # Note that most of this data is loaded from the projectsYmlUrl.
     # These are non-gecko, legacy projects that are not included there.
     bmo-master:
       scopes:

--- a/src/config/production.yml
+++ b/src/config/production.yml
@@ -4,7 +4,7 @@ documentdb:
 config:
   documentkey: production
   # always load the latest production-branches.json at startup
-  productionBranchesUrl: https://hg.mozilla.org/build/tools/raw-file/default/buildfarm/maintenance/production-branches.json
+  projectsYmlUrl: https://hg.mozilla.org/build/ci-configuration/raw-file/tip/projects.yml
   files:
     - production-treeherder-proxy.yml
 

--- a/src/config/stage.yml
+++ b/src/config/stage.yml
@@ -8,7 +8,7 @@ treeherderActions:
 config:
   documentkey: stage
   # always load the latest production-branches.json at startup
-  productionBranchesUrl: https://hg.mozilla.org/build/tools/raw-file/default/buildfarm/maintenance/production-branches.json
+  projectsYmlUrl: https://hg.mozilla.org/build/ci-configuration/raw-file/tip/projects.yml
   files:
     - stage-treeherder-proxy.yml
 

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -7,13 +7,13 @@ suite('config', function() {
     await load('test');
   });
 
-  test('load test config with production-branches.yml', async function() {
+  test('load test config with projects.yml', async function() {
     // this uses a fixed revision and expects specific values.  If the format changes,
     // this will need to be updated to a new revision.
     let config = await load('test', {
       overrides: {
         config: {
-         productionBranchesUrl: 'https://hg.mozilla.org/build/tools/raw-file/63085f07948c/buildfarm/maintenance/production-branches.json',
+          projectsYmlUrl: 'https://hg.mozilla.org/build/ci-configuration/raw-file/94ebf429be75/projects.yml',
         },
       }
     });

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -19,9 +19,9 @@ suite('config', function() {
     });
 
     assert.equal(config.try.projects['try'].level, 1);
-    assert.equal(config.try.projects['try'].scopes[0], 'assume:repo:hg.mozilla.org/try:*');
+    assert.equal(config.try.projects['try'].scopes[0], 'assume:repo:hg.mozilla.org/try:branch:default');
     assert.equal(config.try.projects['mozilla-beta'].level, 3);
-    assert.equal(config.try.projects['mozilla-beta'].scopes[0], 'assume:repo:hg.mozilla.org/releases/mozilla-beta:*');
+    assert.equal(config.try.projects['mozilla-beta'].scopes[0], 'assume:repo:hg.mozilla.org/releases/mozilla-beta:branch:default');
     assert.equal(config.try.projects['testbranch'].level, 7);
     assert.equal(config.try.projects['testbranch'].scopes[0], 'xyz');
   });


### PR DESCRIPTION
In (to mozilla-taskcluster) for a penny, in for a pound..

This is still pulling from the old https://hg.mozilla.org/build/tools/raw-file/default/buildfarm/maintenance/production-branches.json, which is no longer being updated.