### PR TITLE
Don't store redis config in mongo

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -104,10 +104,6 @@ let schema = Joi.object().keys({
     }))
   }),
 
-  redis: Joi.object().keys({
-    host: Joi.string().required()
-  }).unknown(true),
-
   kue: Joi.object().keys({
     purgeCompleted: Joi.boolean(),
     logFailedJobs: Joi.boolean(),

--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -20,7 +20,6 @@ treeherderProxy:
   port: 60025
 
 config: {}
-redis: {}
 pulse: {}
 
 kue:

--- a/src/config/test.yml
+++ b/src/config/test.yml
@@ -27,9 +27,6 @@ treeherder:
     clientId: 'my-client-id'
     secret: 'secret'
 
-redis:
-  host: none
-
 try:
   projects:
     testbranch:

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,3 +1,4 @@
+import url from 'url';
 import createConnection from './db';
 import kue from 'kue';
 
@@ -5,11 +6,19 @@ import Repos from './collections/repositories';
 import PushlogClient from './pushlog/client';
 
 export default async function(config) {
+  let redisUrl = url.parse(process.env.REDIS_URL);
+  let password = redisUrl.auth.split(':')[1];
 
   let db = await createConnection(config.mongo.connectionString);
   let jobs = kue.createQueue({
     prefix: config.kue.prefix,
-    redis: config.redis
+    redis: {
+      port: parseInt(redisUrl.port, 10),
+      host: redisUrl.hostname,
+      options: {
+        auth_pass: password, // I'm not sure why, but this is the format from mongo
+      },
+    },
   });
 
   return {


### PR DESCRIPTION
This is the smallest change I could make. Anything more than this and my head started to hurt.

It should end up passing in exactly what is in mongo currently.


Tests? What are tests? I don't know that anyone has known exactly how to run these tests in a long time.

https://bugzilla.mozilla.org/show_bug.cgi?id=1465606