### PR TITLE
Bug 1465838 - add ci-admin and ci-configuration

### DIFF
--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -117,6 +117,16 @@ try:
       scopes:
         - "assume:repo:github.com/mozilla/webtools-bmo-bugzilla:*"
 
+    ci-admin:
+      level: 3
+      scopes:
+        - "assume:repo:hg.mozilla.org/build/ci-admin:*"
+
+    ci-configuration:
+      level: 3
+      scopes:
+        - "assume:repo:hg.mozilla.org/build/ci-configuration:*"
+
     nss:
       url: "{{{host}}}{{{path}}}/raw-file/{{revision}}/automation/taskcluster/decision_task.yml"
       level: 'nss'


### PR DESCRIPTION
These will need to be imported from treeherder once they are in treeherder, but the config won't hurt.