### PR TITLE
Bug 1501306 - handle scm_nss as level 3

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -151,7 +151,7 @@ async function projectsConfig(url) {
       continue;
     }
 
-    let level = /^scm_(versioncontrol|level_([123]))$/.exec(pb.access);
+    let level = /^scm_(nss|versioncontrol|level_([123]))$/.exec(pb.access);
     if (!level) {
       debug('skipping production branch ' + alias + ': unrecognized access ' + pb.access);
       continue;


### PR DESCRIPTION
The stuff we removed in https://github.com/taskcluster/mozilla-taskcluster/pull/133 set this level to 3, so we never noticed this bit of missing support..