### PR TITLE
Bug 1525368: Update path to ci-config.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,7 +43,7 @@ let schema = Joi.object().keys({
     files: Joi.array().includes(Joi.string()).
       description('list of additional files to load / merge'),
     projectsYmlUrl: Joi.string().
-      description('URL of hg.mozilla.org/build/ci-configuration/projects.yml describing Gecko branches')
+      description('URL of hg.mozilla.org/ci/ci-configuration/projects.yml describing Gecko branches')
   }),
 
   treeherderProxy: Joi.object().keys({

--- a/src/config/production.yml
+++ b/src/config/production.yml
@@ -4,7 +4,7 @@ documentdb:
 config:
   documentkey: production
   # always load the latest production-branches.json at startup
-  projectsYmlUrl: https://hg.mozilla.org/build/ci-configuration/raw-file/tip/projects.yml
+  projectsYmlUrl: https://hg.mozilla.org/ci/ci-configuration/raw-file/tip/projects.yml
   files:
     - production-treeherder-proxy.yml
 

--- a/src/config/stage.yml
+++ b/src/config/stage.yml
@@ -8,7 +8,7 @@ treeherderActions:
 config:
   documentkey: stage
   # always load the latest production-branches.json at startup
-  projectsYmlUrl: https://hg.mozilla.org/build/ci-configuration/raw-file/tip/projects.yml
+  projectsYmlUrl: https://hg.mozilla.org/ci/ci-configuration/raw-file/tip/projects.yml
   files:
     - stage-treeherder-proxy.yml
 

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -13,7 +13,7 @@ suite('config', function() {
     let config = await load('test', {
       overrides: {
         config: {
-          projectsYmlUrl: 'https://hg.mozilla.org/build/ci-configuration/raw-file/e18be5161866/projects.yml',
+          projectsYmlUrl: 'https://hg.mozilla.org/ci/ci-configuration/raw-file/e18be5161866/projects.yml',
         },
       }
     });


### PR DESCRIPTION
This needs to be deployed after the move [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1525368) takes place.